### PR TITLE
Add prebuilt binaries for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: rust
+os: osx
+if: tag IS present
+install: cargo install --force --path .
+script: true
+cache: cargo
+before_deploy: cargo build --release --target=x86_64-apple-darwin && mv target/release/badlogvis target/release/badlogvis-x86_64-apple-darwin
+deploy:
+  provider: releases
+  api_key: $GH_TOKEN
+  file: target/release/badlogvis-x86_64-apple-darwin
+  file_glob: true
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: rust
-os: osx
+matrix:
+  include:
+    - os: osx
+      env: TARGET=x86_64-apple-darwin
+    - os: linux
+      dist: xenial
+      env: TARGET=x86_64-unknown-linux-gnu WIN=x86_64-pc-windows-gnu
+
 if: tag IS present
 install: cargo install --force --path .
 script: true
 cache: cargo
-before_deploy: cargo build --release --target=x86_64-apple-darwin && mv target/release/badlogvis target/release/badlogvis-x86_64-apple-darwin
+before_deploy:
+  - cargo build --release --target=$TARGET && mv target/release/badlogvis target/release/badlogvis-$TARGET
+  - if [ -z "$WIN" ]; then cargo build --release --target=$WIN && mv target/release/badlogvis target/release/$WIN/badlogvis-$WIN; fi
 deploy:
   provider: releases
   api_key: $GH_TOKEN
-  file: target/release/badlogvis-x86_64-apple-darwin
+  file: target/release/**/badlogvis-*
   file_glob: true
   skip_cleanup: true
   on:


### PR DESCRIPTION
The macOS builds are compiled through Travis CI's `osx` environment. Just create a tag and the build should trigger.