### PR TITLE
Update Travis CI badge to reflect latest build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# badlogvis [![Build Status](https://travis-ci.org/dominikWin/badlogvis.svg?branch=master)](https://travis-ci.org/dominikWin/badlogvis)
+# badlogvis [![Build Status](https://travis-ci.org/dominikWin/badlogvis.svg)](https://travis-ci.org/dominikWin/badlogvis)
 
 `badlogvis` is a data log visualization tool that parses badlog bag files or CSV and outputs a single self-contained HTML file.
 


### PR DESCRIPTION
Previously, it would show the current state of the `master` branch build, which was unknown, since we only build on tags.