### PR TITLE
Add builds for aarch64-apple-darwin (Apple Silicon Macs)

### DIFF
--- a/.ci/cross-build.sh
+++ b/.ci/cross-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [[ -n "$WIN" ]]; then
+  rustup target add $WIN &&
+  printf "[target.$WIN]\nlinker = \"x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config &&
+  cargo build --release --target=$WIN &&
+  mv target/$WIN/release/badlogvis.exe target/$WIN/release/badlogvis-$WIN.exe
+fi
+
+if [[ -n "$ARM" ]]; then
+  rustup target add $ARM &&
+  SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) \
+  MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) \
+  cargo build --target=$ARM &&
+  mv target/$ARM/release/badlogvis target/$ARM/release/badlogvis-$ARM
+fi

--- a/.ci/cross-build.sh
+++ b/.ci/cross-build.sh
@@ -10,6 +10,6 @@ if [[ -n "$ARM" ]]; then
   rustup target add $ARM &&
   SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) \
   MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) \
-  cargo build --target=$ARM &&
+  cargo build --release --target=$ARM &&
   mv target/$ARM/release/badlogvis target/$ARM/release/badlogvis-$ARM
 fi

--- a/.ci/win-build.sh
+++ b/.ci/win-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-if [[ -n "$WIN" ]]; then
-  rustup target add $WIN &&
-  printf "[target.$WIN]\nlinker = \"x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config &&
-  cargo build --release --target=$WIN &&
-  mv target/$WIN/release/badlogvis.exe target/$WIN/release/badlogvis-$WIN.exe
-fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: rust
+rust:
+  - beta
 matrix:
   include:
     - os: osx
-      env: TARGET=x86_64-apple-darwin
+      osx_image: xcode12.2
+      env: TARGET=x86_64-apple-darwin ARM=aarch64-apple-darwin
     - os: linux
       dist: xenial
       env: TARGET=x86_64-unknown-linux-gnu WIN=x86_64-pc-windows-gnu
@@ -18,11 +21,11 @@ script: true
 cache: cargo
 before_deploy:
   - cargo build --release --target=$TARGET && mv target/release/badlogvis target/release/badlogvis-$TARGET
-  - .ci/win-build.sh
+  - .ci/cross-build.sh
 deploy:
   provider: releases
   api_key: $GH_TOKEN
-  file: target/**/release/badlogvis-{$TARGET,$WIN.exe}
+  file: target/**/release/badlogvis-{$TARGET,$ARM,$WIN.exe}
   file_glob: true
   skip_cleanup: true
   on:


### PR DESCRIPTION
Tried compiling locally with rust v1.49.0 on an Apple Silicon-based Mac, badlogvis works fine. The binaries build succesfully on Travis CI, the build just fails because the deploy to GitHub Releases fails on my account since my GitHub token is no longer valid.

Feel free to squash the merge if you decide to merge this.