### PR TITLE
Package Linux and Mac binaries as .tar.gz

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo mv ./badlogvis /usr/local/bin

--- a/.ci/package.sh
+++ b/.ci/package.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+mkdir -p out/badlogvis-$TARGET
+cp target/release/badlogvis out/badlogvis-$TARGET/
+cp .ci/install.sh out/badlogvis-$TARGET/
+
+if [[ -n "$ARM" ]]; then
+  mkdir -p out/badlogvis-$ARM
+  cp target/$ARM/release/badlogvis out/badlogvis-$ARM/
+  cp .ci/install.sh out/badlogvis-$ARM/
+fi
+
+cd out/
+tar -czvf badlogvis-$TARGET.tar.gz badlogvis-$TARGET/
+
+if [[ -n "$ARM" ]]; then
+  tar -czvf badlogvis-$ARM.tar.gz badlogvis-$ARM/
+fi
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,9 @@ jobs:
         with:
           command: build
           args: --release --target ${{ env.ARM }}
-      - name: Rename binaries
-        id: rename_binaries
-        run: |
-          mv target/release/badlogvis target/release/badlogvis-${{ env.TARGET }}
-          mv target/${{ env.ARM }}/release/badlogvis target/release/badlogvis-${{ env.ARM }}
+      - name: Package binaries
+        id: package_binaries
+        run: .ci/package.sh
       - name: Publish release with binaries
         id: publish_release
         uses: softprops/action-gh-release@v1
@@ -48,7 +46,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            ./target/release/badlogvis-*
+            ./out/badlogvis-*.tar.gz
   build-linux:
     name: Build for Linux and Windows
     runs-on: ubuntu-latest
@@ -74,9 +72,9 @@ jobs:
       - name: Build for x86_64-pc-windows-gnu
         id: build_windows
         run: .ci/cross-build.sh
-      - name: Rename binaries
-        id: rename_binaries
-        run: mv target/release/badlogvis target/release/badlogvis-${{ env.TARGET }}
+      - name: Package binaries
+        id: package_binaries
+        run: .ci/package.sh
       - name: Publish release with binaries
         id: publish_release
         uses: softprops/action-gh-release@v1
@@ -88,5 +86,7 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            ./target/release/badlogvis-*
+            ./target/release/badlogvis-${{ env.WIN }}.exe
+            ./out/badlogvis-*.tar.gz
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ Cargo.lock
 *.html
 *.bag
 *.csv
+
+.DS_Store
+
+/out/


### PR DESCRIPTION
**Note:** This PR is identical to #11, I'm just closing that one and moving those changes to a new branch so I can roll back that one to match upstream master.

The download sizes are smaller, they come packaged with an install.sh script, and you no longer have to rename the badlogvis binary to remove the target triple suffix, or chmod +x it to give it executable permissions, as tar stores permissions data. Most binaries that aren't shipped with installers seem to be packaged as tar.gz.

I would package Windows as a ZIP with an install.bat script, but I don't know where the standard place to install an executable binary to would be. When I used Windows, I installed badlogvis in a bin folder I created in my user home that I manually added to PATH.

Sample release: https://github.com/richiksc/badlogvis/releases/tag/v0.3.5-rc1