### PR TITLE
Switch back to Rust stable channel

### DIFF
--- a/.ci/cross-build.sh
+++ b/.ci/cross-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-if [[ -n "$WIN" ]]; then
-  sudo apt-get install gcc-mingw-w64 &&
-  printf "[target.$WIN]\nlinker = \"x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config &&
-  cargo build --release --target=$WIN &&
-  mv target/$WIN/release/badlogvis.exe target/release/badlogvis-$WIN.exe
-fi

--- a/.ci/package.sh
+++ b/.ci/package.sh
@@ -4,16 +4,21 @@ mkdir -p out/badlogvis-$TARGET
 cp target/release/badlogvis out/badlogvis-$TARGET/
 cp .ci/install.sh out/badlogvis-$TARGET/
 
-if [[ -n "$ARM" ]]; then
-  mkdir -p out/badlogvis-$ARM
-  cp target/$ARM/release/badlogvis out/badlogvis-$ARM/
-  cp .ci/install.sh out/badlogvis-$ARM/
+mkdir -p out/badlogvis-$SECONDARY
+
+if [[ "$SECONDARY" != "x86_64-pc-windows-gnu" ]]; then
+  cp .ci/install.sh out/badlogvis-$SECONDARY/
+  cp target/$SECONDARY/release/badlogvis out/badlogvis-$SECONDARY/
+else
+  cp target/$SECONDARY/release/badlogvis.exe out/badlogvis-$SECONDARY/
 fi
 
 cd out/
 tar -czvf badlogvis-$TARGET.tar.gz badlogvis-$TARGET/
 
-if [[ -n "$ARM" ]]; then
-  tar -czvf badlogvis-$ARM.tar.gz badlogvis-$ARM/
+if [[ "$SECONDARY" != "x86_64-pc-windows-gnu" ]]; then
+  tar -czvf badlogvis-$SECONDARY.tar.gz badlogvis-$SECONDARY/
+else
+  zip -r badlogvis-$SECONDARY.zip badlogvis-$SECONDARY/
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - 'v*'
+  pull_request:
 
 jobs:
   build:
@@ -12,7 +13,7 @@ jobs:
           - os: macos-11.0
             TARGET: x86_64-apple-darwin
             SECONDARY: aarch64-apple-darwin
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             TARGET: x86_64-unknown-linux-gnu
             SECONDARY: x86_64-pc-windows-gnu
     name: Build (${{ matrix.os }})
@@ -34,7 +35,7 @@ jobs:
           command: build
           args: --release
       - name: Install Windows linker
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           sudo apt-get install gcc-mingw-w64 &&
           printf "[x86_64-pc-windows-gnu]\nlinker = \"x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config
@@ -50,6 +51,7 @@ jobs:
           SECONDARY: ${{ matrix.SECONDARY }}
         run: .ci/package.sh
       - name: Publish release with binaries
+        if: ${{ github.event_name != 'pull_request' }}
         id: publish_release
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,35 +5,49 @@ on:
       - 'v*'
 
 jobs:
-  build-macos:
-    name: Build for macOS
-    runs-on: macos-11.0
-    env:
-      TARGET: x86_64-apple-darwin
-      ARM: aarch64-apple-darwin
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-11.0
+            TARGET: x86_64-apple-darwin
+            SECONDARY: aarch64-apple-darwin
+          - os: ubuntu-latest
+            TARGET: x86_64-unknown-linux-gnu
+            SECONDARY: x86_64-pc-windows-gnu
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set Release Version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Install Rust beta
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: beta
+          toolchain: stable
           default: true
-          target: ${{ env.ARM }} # This is in addition to the native target
+          target: ${{ matrix.SECONDARY }} # This is in addition to the native target
           profile: minimal
-      - name: Build for x86_64-apple-darwin
+      - name: Build for ${{ matrix.TARGET }}
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
-      - name: Build for aarch64-apple-darwin
+      - name: Install Windows linker
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install gcc-mingw-w64 &&
+          printf "[x86_64-pc-windows-gnu]\nlinker = \"x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config
+      - name: Build for ${{ matrix.SECONDARY }}
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target ${{ env.ARM }}
+          args: --release --target ${{ matrix.SECONDARY }}
       - name: Package binaries
         id: package_binaries
+        env:
+          TARGET: ${{ matrix.TARGET }}
+          SECONDARY: ${{ matrix.SECONDARY }}
         run: .ci/package.sh
       - name: Publish release with binaries
         id: publish_release
@@ -47,46 +61,6 @@ jobs:
           prerelease: false
           files: |
             ./out/badlogvis-*.tar.gz
-  build-linux:
-    name: Build for Linux and Windows
-    runs-on: ubuntu-latest
-    env:
-      TARGET: x86_64-unknown-linux-gnu
-      WIN: x86_64-pc-windows-gnu
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set Release Version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Install Rust beta
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: beta
-          default: true
-          target: ${{ env.WIN }} # This is in addition to the native target
-          profile: minimal
-      - name: Build for x86_64-unknown-linux-gnu
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-      - name: Build for x86_64-pc-windows-gnu
-        id: build_windows
-        run: .ci/cross-build.sh
-      - name: Package binaries
-        id: package_binaries
-        run: .ci/package.sh
-      - name: Publish release with binaries
-        id: publish_release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          name: badlogvis ${{ env.RELEASE_VERSION }}
-          draft: false
-          prerelease: false
-          files: |
-            ./target/release/badlogvis-${{ env.WIN }}.exe
-            ./out/badlogvis-*.tar.gz
+            ./out/badlogvis-*.zip
 
 

--- a/src/attached_file.rs
+++ b/src/attached_file.rs
@@ -1,13 +1,13 @@
 use std::fs;
 use std::path::Path;
 
-pub struct AttatchedFile {
+pub struct AttachedFile {
     pub path: String,
     pub name: String,
     content: Vec<u8>,
 }
 
-impl From<&str> for AttatchedFile {
+impl From<&str> for AttachedFile {
     fn from(path: &str) -> Self {
         let content = fs::read(path);
 
@@ -23,7 +23,7 @@ impl From<&str> for AttatchedFile {
             .unwrap()
             .to_string();
 
-        AttatchedFile {
+        AttachedFile {
             content,
             name,
             path: path.to_string(),
@@ -31,7 +31,7 @@ impl From<&str> for AttatchedFile {
     }
 }
 
-impl AttatchedFile {
+impl AttachedFile {
     pub fn get_button_html(&self) -> String {
         let data = base64::encode(&self.content);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ extern crate open;
 
 #[macro_use]
 mod util;
-mod attatched_file;
+mod attached_file;
 mod attribute;
 mod folder;
 mod graph;
@@ -27,7 +27,7 @@ use std::io::prelude::*;
 
 use structopt::StructOpt;
 
-use attatched_file::AttatchedFile;
+use attached_file::AttachedFile;
 use folder::Folder;
 use graph::Graph;
 use input::*;
@@ -109,9 +109,9 @@ fn main() {
     };
 
     let attatched_files = {
-        let mut out = Vec::<AttatchedFile>::new();
+        let mut out = Vec::<AttachedFile>::new();
         for path in &opt.attatched_paths {
-            let file = AttatchedFile::from(path.as_ref());
+            let file = AttachedFile::from(path.as_ref());
             if out.iter().filter(|f| &f.path == path).count() > 0 {
                 warning!("Duplicate paths found for {}", path);
             } else if out.iter().filter(|f| &f.name == &file.name).count() > 0 {
@@ -148,7 +148,7 @@ fn gen_html(
     folders: Vec<Folder>,
     csv_embed: &CsvEmbed,
     json_header: Option<&str>,
-    attatched_files: Vec<AttatchedFile>,
+    attatched_files: Vec<AttachedFile>,
 ) -> String {
     let bootstrap_css_source = include_str!("web_res/bootstrap.min.css");
     let jquery_js_source = include_str!("web_res/jquery-3.2.1.min.js");


### PR DESCRIPTION
Now that Rust v1.49 (which added support for `aarch64-apple-darwin` has been promoted to the stable channel, this PR switches back to Rust stable). It also greatly simplifies the GitHub workflow file using `matrix`.